### PR TITLE
Fix sphinx-gallery issue on read the docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -82,7 +82,7 @@ sphinx_gallery_conf = {
     # Sort gallery example by file name instead of number of lines (default)
     "within_subsection_order": FileNameSortKey,
     # directory where function granular galleries are stored
-    "backreferences_dir": False,
+    "backreferences_dir": None,
     # Modules for which function level galleries are created.  In
     "doc_module": "taco_vis",
     "image_scrapers": ('matplotlib'),


### PR DESCRIPTION
@sam-greenwood, this should fix the strange issue you are having on readthedocs - this was my bad, as I put an invalid value in the sphinx-gallery config when helping setting up the docs gallery.

reference https://github.com/sphinx-gallery/sphinx-gallery/issues/567